### PR TITLE
Reflect successful testing against WordPress 5.7.2

### DIFF
--- a/civievent-widget.php
+++ b/civievent-widget.php
@@ -550,7 +550,10 @@ HEREDOC;
 		$instance = array();
 		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
 		if ( ! empty( $new_instance['wtheme'] ) ) {
-			$instance['wtheme'] = array_shift( explode( ' ', trim( strip_tags( $new_instance['wtheme'] ) ) ) );
+			// Break the user provided widget theme value into an array, split by spaces.
+			$wthemes = explode( ' ', trim( wp_strip_all_tags( $new_instance['wtheme'] ) ) );
+			// Set the widget theme to the first value in the wthemes array.
+			$instance['wtheme'] = array_shift( $wthemes );
 		} else {
 			$instance['wtheme'] = '';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: agh1
 Tags: civicrm, events, event, nonprofit, crm, calendar
 Requires at least: 3.3
-Tested up to: 4.9
+Tested up to: 5.7.2
 Stable tag: 3.2
 License: AGPLv3 or later
 License URI: http://www.gnu.org/licenses/agpl-3.0.html


### PR DESCRIPTION
This PR is to reflect successful testing of civievent-widget version 3.2 against WordPress version 5.7.2. 

Fixes #10.

I found and addressed one PHP notice appearing in the debug log, "Only variables should be passed by reference."

Beyond that, I:

* Confirmed that the plugin could be successfully activated and deactivated
* That the user-facing and admin UI features worked as expected
* That there were no PHP errors or warnings triggered by the plugin

(There were WordPress code standards issues but I would consider those to be beyond the scope of this testing update.)